### PR TITLE
Diary mealcards were covering header on smaller screens. Updated scss…

### DIFF
--- a/lib/styles/pages/manage-diary.scss
+++ b/lib/styles/pages/manage-diary.scss
@@ -1,10 +1,12 @@
 .diary {
   display: flex;
   justify-content: center;
-  align-items: center;
+  // align-items: center;
 
   width: 100%;
   height: 100vh;
+
+  margin-top: 50px;
 
   .diary-frame {
     display: flex;
@@ -119,6 +121,7 @@ header.daily-total {
   background-color: white;
   opacity: .97;
   width: 620px;
+  height: 90px;
   margin: 0px auto;
   border-radius: 10px;
   @include shadow();


### PR DESCRIPTION
… to fix

#### What does this PR do?

Changes mealcard flexbox options so mealcards no longer cover header when screen shrinks

#### Any background context you want to provide?

Still need to stack cads for mobile responsiveness. Also need to add media query and adjust header for smaller screens

#### Questions:
  - Do Migrations Need to be ran? no
  - Do Environment Variables need to be set? no
  - Any other deploy steps?
 no